### PR TITLE
fix find first in model

### DIFF
--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -48,6 +48,6 @@ abstract class BaseModel
         if (!is_array($params)) {
             return static::getSource()::retrieve(strval($params), [], []);
         }
-        return current(static::getSource()::find(Util::convertParams($params)), []);
+        return current(static::getSource()::find(Util::convertParams($params), []));
     }
 }


### PR DESCRIPTION
- php function `current` accept just one param. I think we trying to pass the empty array to `static::getSource()::find` instead.